### PR TITLE
Add Meal entity

### DIFF
--- a/Nutrify AI/ContentView.swift
+++ b/Nutrify AI/ContentView.swift
@@ -12,40 +12,49 @@ struct ContentView: View {
     @Environment(\.managedObjectContext) private var viewContext
 
     @FetchRequest(
-        sortDescriptors: [NSSortDescriptor(keyPath: \Item.timestamp, ascending: true)],
+        sortDescriptors: [NSSortDescriptor(keyPath: \Meal.timestamp, ascending: true)],
         animation: .default)
-    private var items: FetchedResults<Item>
+    private var meals: FetchedResults<Meal>
 
     var body: some View {
         NavigationView {
             List {
-                ForEach(items) { item in
+                ForEach(meals) { meal in
                     NavigationLink {
-                        Text("Item at \(item.timestamp!, formatter: itemFormatter)")
+                        Text(meal.name ?? "Unnamed")
                     } label: {
-                        Text(item.timestamp!, formatter: itemFormatter)
+                        VStack(alignment: .leading) {
+                            Text(meal.name ?? "Unnamed")
+                            Text(meal.timestamp!, formatter: itemFormatter)
+                                .font(.caption)
+                        }
                     }
                 }
-                .onDelete(perform: deleteItems)
+                .onDelete(perform: deleteMeals)
             }
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     EditButton()
                 }
                 ToolbarItem {
-                    Button(action: addItem) {
-                        Label("Add Item", systemImage: "plus")
+                    Button(action: addMeal) {
+                        Label("Add Meal", systemImage: "plus")
                     }
                 }
             }
-            Text("Select an item")
+            Text("Select a meal")
         }
     }
 
-    private func addItem() {
+    private func addMeal() {
         withAnimation {
-            let newItem = Item(context: viewContext)
-            newItem.timestamp = Date()
+            let newMeal = Meal(context: viewContext)
+            newMeal.name = "New Meal"
+            newMeal.calories = 0
+            newMeal.protein = 0
+            newMeal.carbs = 0
+            newMeal.fat = 0
+            newMeal.timestamp = Date()
 
             do {
                 try viewContext.save()
@@ -58,9 +67,9 @@ struct ContentView: View {
         }
     }
 
-    private func deleteItems(offsets: IndexSet) {
+    private func deleteMeals(offsets: IndexSet) {
         withAnimation {
-            offsets.map { items[$0] }.forEach(viewContext.delete)
+            offsets.map { meals[$0] }.forEach(viewContext.delete)
 
             do {
                 try viewContext.save()

--- a/Nutrify AI/Nutrify_AI.xcdatamodeld/Nutrify_AI.xcdatamodel/contents
+++ b/Nutrify AI/Nutrify_AI.xcdatamodeld/Nutrify_AI.xcdatamodel/contents
@@ -3,7 +3,16 @@
     <entity name="Item" representedClassName="Item" syncable="YES" codeGenerationType="class">
         <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
+    <entity name="Meal" representedClassName="Meal" syncable="YES" codeGenerationType="class">
+        <attribute name="name" optional="YES" attributeType="String" usesScalarValueType="NO"/>
+        <attribute name="calories" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="protein" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="carbs" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="fat" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
     <elements>
         <element name="Item" positionX="-63" positionY="-18" width="128" height="44"/>
+        <element name="Meal" positionX="0" positionY="0" width="128" height="44"/>
     </elements>
 </model>

--- a/Nutrify AI/Persistence.swift
+++ b/Nutrify AI/Persistence.swift
@@ -14,9 +14,14 @@ struct PersistenceController {
     static let preview: PersistenceController = {
         let result = PersistenceController(inMemory: true)
         let viewContext = result.container.viewContext
-        for _ in 0..<10 {
-            let newItem = Item(context: viewContext)
-            newItem.timestamp = Date()
+        for i in 0..<10 {
+            let newMeal = Meal(context: viewContext)
+            newMeal.name = "Sample Meal \(i)"
+            newMeal.calories = 0
+            newMeal.protein = 0
+            newMeal.carbs = 0
+            newMeal.fat = 0
+            newMeal.timestamp = Date()
         }
         do {
             try viewContext.save()


### PR DESCRIPTION
## Summary
- define a `Meal` entity with nutrition fields in the Core Data model
- generate preview data for `Meal` and adapt persistent controller
- update UI to list and create `Meal` objects

## Testing
- `swift --version`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401816d1d08326beed4de09de461e3