### PR TITLE
Fix Meal missing type

### DIFF
--- a/Nutrify AI/Meal.swift
+++ b/Nutrify AI/Meal.swift
@@ -1,0 +1,20 @@
+import Foundation
+import CoreData
+
+@objc(Meal)
+public class Meal: NSManagedObject {
+    @NSManaged public var name: String?
+    @NSManaged public var calories: Double
+    @NSManaged public var protein: Double
+    @NSManaged public var carbs: Double
+    @NSManaged public var fat: Double
+    @NSManaged public var timestamp: Date?
+}
+
+extension Meal {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Meal> {
+        NSFetchRequest<Meal>(entityName: "Meal")
+    }
+}
+
+extension Meal: Identifiable {}


### PR DESCRIPTION
## Summary
- add Core Data NSManagedObject subclass for `Meal`

## Testing
- `swiftc -parse "Nutrify AI/ContentView.swift"`
- `swiftc -parse "Nutrify AI/Nutrify_AIApp.swift"`
- `swiftc -parse "Nutrify AI/Persistence.swift"`
- `swiftc -parse "Nutrify AITests/Nutrify_AITests.swift"`
- `swiftc -parse "Nutrify AIUITests/Nutrify_AIUITests.swift"`
- `swiftc -parse "Nutrify AIUITests/Nutrify_AIUITestsLaunchTests.swift"`


------
https://chatgpt.com/codex/tasks/task_e_684024281e4c832689aa42d0c434e185